### PR TITLE
Add "ignore" option to silence errors for certain modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,25 @@ rules: {
   ]
 }
 ```
+
+### Ignoring packages
+
+To suppress `no-implicit` errors for a particular package, add `ignore` to the rule’s configuration. This can be useful when import aliases are in use, and an import that looks like an npm package is actually local to the source tree:
+
+```yaml
+rules:
+  - implicit-dependencies/no-implicit:
+    - error
+    - ignore: ['src', '@/components']
+```
+
+Or if configuring with javascript:
+
+```javascript
+rules: {
+  'implicit-dependencies/no-implicit': [
+    'error',
+    { ignore: ['src', '@/components'] }
+  ]
+}
+```

--- a/rules/no-implicit-dependencies.js
+++ b/rules/no-implicit-dependencies.js
@@ -21,17 +21,27 @@ module.exports = {
           },
           dev: {
             type: 'boolean'
-          }
+          },
+
+          ignore: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+          },
         },
         additionalProperties: false
       }
     ]
   },
   create: (context) => {
+    const opts = context.options[0] || {};
+
     // find the nearest package.json
     const dir = path.dirname(context.getFilename());
     const jsonPath = path.join(findup.sync(dir, 'package.json'), 'package.json');
     const pkg = require(jsonPath);
+
     const checkModuleName = (name, node) => {
       let moduleName;
 
@@ -52,8 +62,12 @@ module.exports = {
           moduleName = name.split('/')[0];
         }
 
+        // skip modules that are explicitly ignored in the rule's options
+        if (opts.ignore && opts.ignore.includes(moduleName)) {
+          return;
+        }
+
         // check dependencies
-        const opts = context.options[0] || {};
         if (pkg.dependencies && pkg.dependencies[moduleName]) {
           return;
         } else if (pkg.optionalDependencies && pkg.optionalDependencies[moduleName] && opts.optional) {


### PR DESCRIPTION
We have a similar configuration to what’s described in #2, where we can import top-level modules from the local package with a `src/…` alias. This simplifies what would be possibly deep relative imports like `../../../util/log`. I know next.js [also supports](https://nextjs.org/docs/advanced-features/module-path-aliases) a similar feature natively.

To make this plugin usable in these cases, this adds an `ignore` option to the `no-implicit` rule’s options.