### PR TITLE
Add `include` option to analyze specific modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,27 @@ rules: {
   ]
 }
 ```
+
+### Restricting packages
+
+To only assert about missing dependecies on specific packages, add a regular expression to the `include` rule configuration. That way only packages that match the given regex will be evaluated.
+
+For instance, to match packages like `@my_target_module/util`, you could configure as:
+
+```yaml
+rules:
+  - implicit-dependencies/no-implicit:
+    - error
+    - include: /@my_target_module\/.+$/
+```
+
+Or if configuring with javascript:
+
+```javascript
+rules: {
+  'implicit-dependencies/no-implicit': [
+    'error',
+    { include: /@my_target_module\/.+$/ }
+  ]
+}
+```

--- a/rules/no-implicit-dependencies.js
+++ b/rules/no-implicit-dependencies.js
@@ -22,7 +22,7 @@ module.exports = {
           dev: {
             type: 'boolean'
           },
-          targetModulesPattern: {
+          include: {
             type: 'regular expression'
           }
         },
@@ -57,7 +57,7 @@ module.exports = {
 
         const opts = context.options[0] || {};
 
-        if (opts.targetModulesPattern && !moduleName.match(opts.targetModulesPattern)) {
+        if (opts.include && !moduleName.match(opts.include)) {
           return;
         }
 

--- a/rules/no-implicit-dependencies.js
+++ b/rules/no-implicit-dependencies.js
@@ -21,6 +21,9 @@ module.exports = {
           },
           dev: {
             type: 'boolean'
+          },
+          targetModulesPattern: {
+            type: 'regular expression'
           }
         },
         additionalProperties: false
@@ -52,8 +55,13 @@ module.exports = {
           return;
         }
 
-        // check dependencies
         const opts = context.options[0] || {};
+
+        if (opts.targetModulesPattern && !moduleName.match(opts.targetModulesPattern)) {
+          return;
+        }
+
+        // check dependencies
         if (pkg.dependencies && pkg.dependencies[moduleName]) {
           return;
         } else if (pkg.optionalDependencies && pkg.optionalDependencies[moduleName] && opts.optional) {


### PR DESCRIPTION
Adds an include option so that a client can specify which packages are relevant to be analyzed.

For instance, to match packages like `@my_target_module/util`, you could configure as:

```yaml
rules:
  - implicit-dependencies/no-implicit:
    - error
    - include: /@my_target_module\/.+$/
```

Or if configuring with javascript:

```javascript
rules: {
  'implicit-dependencies/no-implicit': [
    'error',
    { include: /@my_target_module\/.+$/ }
  ]
}
```