### PR TITLE
Ignore `node:` modules

### DIFF
--- a/rules/no-implicit-dependencies.js
+++ b/rules/no-implicit-dependencies.js
@@ -51,6 +51,10 @@ module.exports = {
         if (builtin[moduleName]) {
           return;
         }
+        // if module is a `node:` module, skip that too
+        if (moduleName.startsWith('node:')) {
+          return;
+        }
 
         // check dependencies
         const opts = context.options[0] || {};


### PR DESCRIPTION
Closes #7 . If a module being imported starts with `node:`, it's a [builtin module](https://nodejs.org/api/esm.html#node-imports), and therefore should never trigger this lint rule.